### PR TITLE
Downloading the images fixed

### DIFF
--- a/tags/review.tag.html
+++ b/tags/review.tag.html
@@ -1,13 +1,16 @@
 <review>
     <style>
+        .photolist-wrapper{
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, auto));
+            grid-gap: 15px;
+        }
         .cardframe{
-            display: block;
             background-color: white;
             float: left;
-            margin: 7px;
             border-radius: 5px;
-            padding: 5px;
             position: relative;
+            overflow: hidden;
         }
         .symbol{
             position: absolute;

--- a/tags/review.tag.html
+++ b/tags/review.tag.html
@@ -1,10 +1,5 @@
 <review>
     <style>
-        .photolist-wrapper{
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, auto));
-            grid-gap: 15px;
-        }
         .cardframe{
             background-color: white;
             float: left;
@@ -56,9 +51,7 @@
                     <div each={ symbol in card} class="symbol trans"  h={readSymbol(symbol).size.height} w={readSymbol(symbol).size.width}  
                         weight={ Math.abs(calculateWeight( readSymbol(symbol).size )) }>
                         <img  src={ readSymbol(symbol,true).src }>
-                        
                     </div>
-                    
                 </div>
             </div>
         </div>
@@ -109,6 +102,13 @@
             //$(".ui-resizable-handle").hide(); hiding this causes the card to not have a drag handle after clicking on generate
             $(".cardframe").mouseover( function(e) {
                 $(this).find(".resizeHandle, .ui-rotatable-handle, .ui-resizable-handle").show();
+            });
+
+            // Fixing the cards grid
+            $(".photolist-wrapper").css({
+                "display" : "grid",
+                "grid-template-columns" : `repeat(auto-fill, minmax(${this.frame.width}px, auto))`,
+                "grid-gap": "15px"
             });
 
             $(".cardframe").mouseout( function(e) {


### PR DESCRIPTION
Responsiveness is working. Only when cards are the larger size they overlap a bit before to wrap.
This can be changed by adjusting the minimum size of the grid cell.
![untitled](https://user-images.githubusercontent.com/36127650/46919715-24fabe00-cfdb-11e8-9f87-b3e0fd76a4f8.png)
